### PR TITLE
Update dependencies to use Prisma v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,31 @@
 {
   "name": "prisma-extension-cache-manager",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-extension-cache-manager",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "cache-manager": "^5.2.3",
         "object-code": "^1.3.0"
       },
       "devDependencies": {
-        "@prisma/client": "^5.3.1",
+        "@prisma/client": "^6.0.1",
         "@types/lodash": "^4.14.199",
         "npm-run-all": "^4.1.5",
-        "prisma": "^5.3.1",
+        "prisma": "^6.0.1",
         "rimraf": "^5.0.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       },
+      "engines": {
+        "node": ">=18.18"
+      },
       "peerDependencies": {
-        "@prisma/client": "^5.3.1"
+        "@prisma/client": "^6.0.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -90,16 +93,13 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.3.1.tgz",
-      "integrity": "sha512-ArOKjHwdFZIe1cGU56oIfy7wRuTn0FfZjGuU/AjgEBOQh+4rDkB6nF+AGHP8KaVpkBIiHGPQh3IpwQ3xDMdO0Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.0.1.tgz",
+      "integrity": "sha512-60w7kL6bUxz7M6Gs/V+OWMhwy94FshpngVmOY05TmGD0Lhk+Ac0ZgtjlL6Wll9TD4G03t4Sq1wZekNVy+Xdlbg==",
       "dev": true,
       "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines-version": "5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59"
-      },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -110,18 +110,50 @@
         }
       }
     },
+    "node_modules/@prisma/debug": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.0.1.tgz",
+      "integrity": "sha512-jQylgSOf7ibTVxqBacnAlVGvek6fQxJIYCQOeX2KexsfypNzXjJQSS2o5s+Mjj2Np93iSOQUaw6TvPj8syhG4w==",
+      "dev": true
+    },
     "node_modules/@prisma/engines": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.3.1.tgz",
-      "integrity": "sha512-6QkILNyfeeN67BNEPEtkgh3Xo2tm6D7V+UhrkBbRHqKw9CTaz/vvTP/ROwYSP/3JT2MtIutZm/EnhxUiuOPVDA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.0.1.tgz",
+      "integrity": "sha512-4hxzI+YQIR2uuDyVsDooFZGu5AtixbvM2psp+iayDZ4hRrAHo/YwgA17N23UWq7G6gRu18NvuNMb48qjP3DPQw==",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/fetch-engine": "6.0.1",
+        "@prisma/get-platform": "6.0.1"
+      }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59.tgz",
-      "integrity": "sha512-y5qbUi3ql2Xg7XraqcXEdMHh0MocBfnBzDn5GbV1xk23S3Mq8MGs+VjacTNiBh3dtEdUERCrUUG7Z3QaJ+h79w==",
+      "version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e.tgz",
+      "integrity": "sha512-JmIds0Q2/vsOmnuTJYxY4LE+sajqjYKhLtdOT6y4imojqv5d/aeVEfbBGC74t8Be1uSp0OP8lxIj2OqoKbLsfQ==",
       "dev": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.0.1.tgz",
+      "integrity": "sha512-T36bWFVGeGYYSyYOj9d+O9G3sBC+pAyMC+jc45iSL63/Haq1GrYjQPgPMxrEj9m739taXrupoysRedQ+VyvM/Q==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/get-platform": "6.0.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.0.1.tgz",
+      "integrity": "sha512-zspC9vlxAqx4E6epMPMLLBMED2VD8axDe8sPnquZ8GOsn6tiacWK0oxrGK4UAHYzYUVuMVUApJbdXB2dFpLhvg==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/debug": "6.0.1"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -588,6 +620,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1304,19 +1350,22 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.3.1.tgz",
-      "integrity": "sha512-Wp2msQIlMPHe+5k5Od6xnsI/WNG7UJGgFUJgqv/ygc7kOECZapcSz/iU4NIEzISs3H1W9sFLjAPbg/gOqqtB7A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.0.1.tgz",
+      "integrity": "sha512-CaMNFHkf+DDq8zq3X/JJsQ4Koy7dyWwwtOKibkT/Am9j/tDxcfbg7+lB1Dzhx18G/+RQCMgjPYB61bhRqteNBQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.3.1"
+        "@prisma/engines": "6.0.1"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-extension-cache-manager",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "author": "Roberto Sero",
   "description": "Prisma client extension for caching model queries",
@@ -28,14 +28,17 @@
     "test": "node --test --test-only --require ts-node/register ./test/*.test.ts",
     "pretest": "prisma db push --force-reset --accept-data-loss --schema=./test/prisma/schema.prisma"
   },
+  "engines": {
+    "node": ">=18.18"
+  },
   "peerDependencies": {
-    "@prisma/client": "^5.3.1"
+    "@prisma/client": "^6.0.1"
   },
   "devDependencies": {
-    "@prisma/client": "^5.3.1",
+    "@prisma/client": "^6.0.1",
     "@types/lodash": "^4.14.199",
     "npm-run-all": "^4.1.5",
-    "prisma": "^5.3.1",
+    "prisma": "^6.0.1",
     "rimraf": "^5.0.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
This package is not compatible with the new **major** release of [Prisma](https://github.com/prisma/prisma). Feel free to change it if you want to maintain the same version compatible with v5 and v6.